### PR TITLE
Fix issues with large 16bit code units

### DIFF
--- a/src/NReco.Text.AhoCorasickDoubleArrayTrie/AhoCorasickDoubleArrayTrie.Builder.cs
+++ b/src/NReco.Text.AhoCorasickDoubleArrayTrie/AhoCorasickDoubleArrayTrie.Builder.cs
@@ -166,10 +166,7 @@ namespace NReco.Text
 				progress = 0;
 				this.keySize = keySize;
 
-				int totalKeysLen = 0;
-				for (int i = 0; i < trie.l.Length; i++)
-					totalKeysLen += trie.l[i];
-				resize(65536 + totalKeysLen*2 + 1);  // originally was 65536*32  -- it seems too large in most cases
+				resize(65536 * 32);
 
 				trie.@base[0] = 1;
 				nextCheckPos = 0;

--- a/src/NReco.Text.AhoCorasickDoubleArrayTrie/AhoCorasickDoubleArrayTrie.State.cs
+++ b/src/NReco.Text.AhoCorasickDoubleArrayTrie/AhoCorasickDoubleArrayTrie.State.cs
@@ -29,7 +29,7 @@ namespace NReco.Text
 
 			private ISet<int> emits = null;
 
-			private Dictionary<char, State> success = new Dictionary<char, State>();
+			private IDictionary<char, State> success = new SortedDictionary<char, State>();
 
 			private int index;
 
@@ -131,7 +131,7 @@ namespace NReco.Text
 				return sb.ToString();
 			}
 
-			public Dictionary<char, State> getSuccess() {
+			public IDictionary<char, State> getSuccess() {
 				return success;
 			}
 


### PR DESCRIPTION
Given a 16bit code units (Fullwidth Left/Right Parenthesis and others)
the optimization in `buildDoubleArrayTrie` doesn't work anymore and we
should revert to the Java implementation's allocation again.

Furthermore, the Java implementation used a `TreeMap<Character, State>`
which is _ordered_ by its key, whereas the port used a
`Dictionary<char, State>` instead which doesn't define any order. This
becomes a problem when iterating over the entries, creating a `List` in
the builder's `fetch` method, then accessing the last item in that list
by index to determine the new Trie size in `insert`.

This solves #4 