### PR TITLE
Use default(V) for hits if values weren't loaded

### DIFF
--- a/src/NReco.Text.AhoCorasickDoubleArrayTrie/AhoCorasickDoubleArrayTrie.cs
+++ b/src/NReco.Text.AhoCorasickDoubleArrayTrie/AhoCorasickDoubleArrayTrie.cs
@@ -106,8 +106,9 @@ namespace NReco.Text
 				if (hitArray != null) {
 					for (int i = 0; i < hitArray.Length; i++) {
 						var hit = hitArray[i];
-						// begin, end, value
-						if (!processor(new Hit(position - l[hit], position, v[hit], hit)))
+                        // begin, end, value
+                        V value = v == null ? default(V) : v[hit];
+						if (!processor(new Hit(position - l[hit], position, value, hit)))
 							return;
 					}
 				}


### PR DESCRIPTION
As discussed in #3, the current implementation allows for the caller to omit values in the on-disk format, but this results in a broken trie when loaded back.
This is just fixing the `NullReferenceException` in that state by returning a `Hit` with a value of `default(V)` in the cases where values aren't required.

In the future the discussed overloaded `Load()` to re-initialize values might be interesting.

Resolves #3 